### PR TITLE
Codellama FIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ Set the model field on the params returned by the builder (or the static params 
 
 This provider uses the llama.cpp server example - start the [server](https://github.com/ggerganov/llama.cpp/tree/master/examples/server) before running prompts with this provider.
 
+#### Codellama
+This is a llama.cpp based provider specialized for codellama infill / Fill in the Middle. Only 7B and 13B models support FIM, and the base models (not Instruct) seem to work better. Start the llama.cpp server example with one of the two supported models before using this provider.
+
 #### Kobold
 For older models that don't work with llama.cpp, koboldcpp might still support them. Check their [repo](https://github.com/LostRuins/koboldcpp/) for setup info.
 

--- a/lua/llm/prompts/starters.lua
+++ b/lua/llm/prompts/starters.lua
@@ -77,18 +77,7 @@ return {
     end
   },
   llamacpp = llamacpp.default_prompt,
-  codellama = {
-    provider = codellama,
-    mode = llm.mode.INSERT,
-    -- weird things happen if we have a visual selection
-    params = {
-      temperature = 0.2
-    },
-    builder = function(_, context)
-      -- just for FIM
-      return prompts.limit_before_after(context, 30)
-    end
-  },
+  codellama = codellama.default_prompt,
   ['hf starcoder'] = {
     provider = huggingface,
     options = {

--- a/lua/llm/prompts/starters.lua
+++ b/lua/llm/prompts/starters.lua
@@ -14,6 +14,7 @@ local palm = require('llm.providers.palm')
 local huggingface = require('llm.providers.huggingface')
 local kobold = require('llm.providers.kobold')
 local llamacpp = require('llm.providers.llamacpp')
+local codellama = require('llm.providers.codellama')
 
 local function standard_code(input, context)
   local surrounding_text = prompts.limit_before_after(context, 30)
@@ -76,6 +77,18 @@ return {
     end
   },
   llamacpp = llamacpp.default_prompt,
+  codellama = {
+    provider = codellama,
+    mode = llm.mode.INSERT,
+    -- weird things happen if we have a visual selection
+    params = {
+      temperature = 0.2
+    },
+    builder = function(_, context)
+      -- just for FIM
+      return prompts.limit_before_after(context, 30)
+    end
+  },
   ['hf starcoder'] = {
     provider = huggingface,
     options = {

--- a/lua/llm/providers/codellama.lua
+++ b/lua/llm/providers/codellama.lua
@@ -91,15 +91,12 @@ function M.request_completion(handlers, params, options)
 
             if data == nil then
               handlers.on_error('Failed to decode: ' .. item)
-              return
-            end
-
-            if data.stop then
+            elseif data.stop then
               local strip_eot = completion:gsub(' <EOT>$', '') -- We can probably drop this eventually when llama.cpp adds the codellama special tokens (32010+)
               handlers.on_finish(strip_eot)
             else
-              handlers.on_partial(data.content)
               completion = completion .. data.content
+              handlers.on_partial(data.content)
             end
           end)
         end,

--- a/lua/llm/providers/codellama.lua
+++ b/lua/llm/providers/codellama.lua
@@ -115,7 +115,7 @@ M.default_prompt = {
   provider = M,
   mode = llm.mode.INSERT, -- weird things happen if we have a visual selection
   params = {
-    temperature = 0.1
+    temperature = 0.1 -- Seems to rarely decode EOT if temp is high
   },
   builder = function(_, context)
     -- we ignore input since this is just for FIM

--- a/lua/llm/providers/codellama.lua
+++ b/lua/llm/providers/codellama.lua
@@ -1,3 +1,5 @@
+local llm = require('llm')
+local prompts = require('llm.prompts')
 local curl = require('llm.curl')
 local util = require('llm.util')
 local async = require('llm.util.async')
@@ -17,8 +19,8 @@ local BOS = 1
 local EOS = 2
 
 ---@param handlers StreamHandlers
----@param params { before: string, after: string, existing?: string }
----@param options { url?: string } Url to running llamacpp server root (e.g. http://localhost:8080/)
+---@param params { before: string, after: string } -- text before and after cursor position
+---@param options { url?: string } Url to running llamacpp server root (defaults to http://localhost:8080/)
 function M.request_completion(handlers, params, options)
   local cancel = nil
 
@@ -108,5 +110,18 @@ function M.request_completion(handlers, params, options)
 
   return function() cancel() end
 end
+
+M.default_prompt = {
+  provider = M,
+  mode = llm.mode.INSERT, -- weird things happen if we have a visual selection
+  params = {
+    temperature = 0.1
+  },
+  builder = function(_, context)
+    -- we ignore input since this is just for FIM
+    -- TODO figure out how to add instructions to FIM in Instruct models
+    return prompts.limit_before_after(context, 30)
+  end
+}
 
 return M

--- a/lua/llm/util.lua
+++ b/lua/llm/util.lua
@@ -124,6 +124,18 @@ function M.table.flatten(tbls)
   return results
 end
 
+--- Copies table without the given key
+function M.table.without(tbl, key)
+  local result = {}
+  for k, v in pairs(tbl) do
+    if k ~= key then
+      result[k] = v
+    end
+  end
+
+  return result
+end
+
 M.json = {}
 
 function M.json.decode(string)

--- a/lua/llm/util.lua
+++ b/lua/llm/util.lua
@@ -79,6 +79,19 @@ function M.table.map_to_array(table, fn)
   return result
 end
 
+--- Appends two list-like tables into one table. xs then ys
+function M.table.append(xs, ys)
+  local res = {}
+  for _,v in ipairs(xs) do
+    table.insert(res, v)
+  end
+  for _,v in ipairs(ys) do
+    table.insert(res, v)
+  end
+
+  return res
+end
+
 --- Gets the 0-indexed subslice of a list table
 function M.table.slice(tbl, start, stop)
   local function idx(x)

--- a/lua/llm/util.lua
+++ b/lua/llm/util.lua
@@ -79,19 +79,6 @@ function M.table.map_to_array(table, fn)
   return result
 end
 
---- Appends two list-like tables into one table. xs then ys
-function M.table.append(xs, ys)
-  local res = {}
-  for _,v in ipairs(xs) do
-    table.insert(res, v)
-  end
-  for _,v in ipairs(ys) do
-    table.insert(res, v)
-  end
-
-  return res
-end
-
 --- Gets the 0-indexed subslice of a list table
 function M.table.slice(tbl, start, stop)
   local function idx(x)


### PR DESCRIPTION
This is a llamacpp based provider that only supports infill with codellama 7b and 13b, which require special token handling. Note that the base models seem to perform better than Instruct models. I'm also not sure how to actually add instructions to a FIM prompt.

https://github.com/gsuuon/llm.nvim/assets/6422188/751310e5-4758-4adc-a69d-fb7c5c892490

