### PR TITLE
Undojoin segment edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ https://user-images.githubusercontent.com/6422188/233773449-3b85355b-bad1-4e40-a
 ```lua
 require('llm').setup({
   default_prompt? = .. , -- Prompt — modify the default prompt (`:Llm` with no argument)
-  hl_group? = '', -- string — Set the default highlight group of in-progress responses
-  prompts? = {} -- table<string, Prompt>` — add prompt alternatives
+  hl_group? = '',        -- string — set the default highlight group of in-progress responses
+  prompts? = {}          -- table<string, Prompt>` — add prompt alternatives
+  join_undo? = false     -- boolean — join streaming response text as a single `u` undo. use if you intend to wait for responses to finish before editing other text, as edits during streaming will also be undone.
 })
 ```
 

--- a/lua/llm/init.lua
+++ b/lua/llm/init.lua
@@ -195,19 +195,10 @@ local function setup_commands()
 end
 
 function M.setup(opts)
-  local _opts = {
+  local _opts = vim.tbl_deep_extend('force', {
     hl_group = 'Comment',
-  }
-
-  if (opts or {}).default_prompt == nil then
-    local openai = require('llm.providers.openai')
-
-    _opts.default_prompt = openai.default_prompt
-  end
-
-  if opts ~= nil then
-    _opts = vim.tbl_deep_extend('force', _opts, opts)
-  end
+    default_prompt = require('llm.providers.openai').default_prompt
+  }, opts or {})
 
   if _opts.prompts then
     scopes.set_global_user_prompts(_opts.prompts)

--- a/lua/llm/init.lua
+++ b/lua/llm/init.lua
@@ -204,6 +204,10 @@ function M.setup(opts)
     scopes.set_global_user_prompts(_opts.prompts)
   end
 
+  if _opts.join_undo then
+    segment.join_undo = true
+  end
+
   setup_commands()
 
   M.opts = _opts


### PR DESCRIPTION
Adds `join_undo` option to enable joining undos. Will also undo any edits made elsewhere in buffer during streaming but for folks who don't edit while streaming (most users?) this is more intuitive. It also avoids adding a bunch of undo nodes due to streaming in text, which makes it harder to get to the undo nodes from before the response. May make this enabled by default eventually.

closes #18 