### PR TITLE
Openai proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ I recommend setting this only during active prompt development, and switching to
 
 ### Providers
 #### OpenAI ChatGPT (default)
-Set the environment variable `OPENAI_API_KEY` to your [api key](https://platform.openai.com/account/api-keys) before starting nvim. OpenAI prompts can take an additional option field with a table containing `{ url?, endpoint?, authorization? }` fields to talk to compatible API's. Check the `compat` starter prompt for an example.
+Set the environment variable `OPENAI_API_KEY` to your [api key](https://platform.openai.com/account/api-keys) before starting nvim. OpenAI prompts can take an additional option field with a table containing `{ url?, endpoint?, authorization?, curl_args? }` fields to talk to compatible API's. Check the `compat` starter prompt for an example.
 
 <details>
 <summary>

--- a/lua/llm/curl.lua
+++ b/lua/llm/curl.lua
@@ -8,6 +8,12 @@ local function build_args(opts, stream)
     '-sS', -- silent (no progress) but show errors
   }
 
+  if opts.args ~= nil and vim.tbl_islist(opts.args) then
+    for _,arg in ipairs(opts.args) do
+      table.insert(args, arg)
+    end
+  end
+
   if stream then
     table.insert(args, '-N') -- no buffer
   end

--- a/lua/llm/providers/openai.lua
+++ b/lua/llm/providers/openai.lua
@@ -46,7 +46,7 @@ end
 
 ---@param handlers StreamHandlers
 ---@param params? any Additional options for OpenAI endpoint
----@param options? { url?: string, endpoint?: string, authorization?: string } Request endpoint and url. Defaults to 'https://api.openai.com/v1/' and 'chat/completions'. `authorization` overrides the request auth header. If url is provided, then only the authorization given here will be used (the environment key will be ignored).
+---@param options? { url?: string, endpoint?: string, authorization?: string, curl_args?: string[] } Request endpoint and url. Defaults to 'https://api.openai.com/v1/' and 'chat/completions'. `authorization` overrides the request auth header. If url is provided, then only the authorization given here will be used (the environment key will be ignored).
 function M.request_completion(handlers, params, options)
   local _all_content = ''
   options = options or {}
@@ -115,7 +115,8 @@ function M.request_completion(handlers, params, options)
     headers = headers,
     method = 'POST',
     url = url_ .. endpoint,
-    body = body
+    body = body,
+    args = options.curl_args
   }, handle_raw, handle_error)
 end
 


### PR DESCRIPTION
Can set `curl_args` in openai prompt options to add additional arguments to curl:
```lua
  gpt = vim.tbl_extend('force', openai.default_prompt, {
    options = {
      curl_args = {'--my-extra-args', '--go-here'}
    }
  })
```

Resolves #31