### PR TITLE
feat(model): update Perplexity provider with enhanced search result citations

### DIFF
--- a/lua/model/providers/perplexity.lua
+++ b/lua/model/providers/perplexity.lua
@@ -27,9 +27,9 @@ local function extract_chat_data(item)
 
   if data ~= nil and data.choices ~= nil then
     return {
-      citations = data.citations,
       content = (data.choices[1].delta or {}).content,
       finish_reason = data.choices[1].finish_reason,
+      search_results = data.search_results,
     }
   end
 end
@@ -80,8 +80,12 @@ function M.request_completion(handlers, params, options)
 
         if data.finish_reason ~= nil then
           completion = completion .. citations_delimit_start
-          for index, citation in ipairs(data.citations) do
-            completion = completion .. index .. '. <' .. citation .. '>\n'
+          for index, result in ipairs(data.search_results) do
+            completion = completion .. index .. '. '
+            completion = completion .. '[' .. result.title .. '](' .. result.url ..') '
+            completion = completion .. result.snippet .. ' '
+            completion = completion .. '(Published: ' .. (result.date or '') .. ', Updated: ' .. (result.last_updated or '') .. ')'
+            completion = completion .. '\n'
           end
           completion = completion .. citations_delimit_stop
           handlers.on_finish(completion, data.finish_reason)

--- a/lua/model/providers/perplexity.lua
+++ b/lua/model/providers/perplexity.lua
@@ -81,11 +81,15 @@ function M.request_completion(handlers, params, options)
         if data.finish_reason ~= nil then
           completion = completion .. citations_delimit_start
           for index, result in ipairs(data.search_results) do
-            completion = completion .. index .. '. '
-            completion = completion .. '[' .. result.title .. '](' .. result.url ..') '
-            completion = completion .. result.snippet .. ' '
-            completion = completion .. '(Published: ' .. (result.date or '') .. ', Updated: ' .. (result.last_updated or '') .. ')'
-            completion = completion .. '\n'
+            completion = completion
+              .. string.format('%d.', index)
+              .. string.format(' [%s](%s)', result.title, result.url)
+              .. result.snippet
+              .. string.format(
+                ' (Published: %s, Updated: %s)\n',
+                result.date or '',
+                result.last_updated or ''
+              )
           end
           completion = completion .. citations_delimit_stop
           handlers.on_finish(completion, data.finish_reason)

--- a/lua/model/providers/perplexity.lua
+++ b/lua/model/providers/perplexity.lua
@@ -84,7 +84,7 @@ function M.request_completion(handlers, params, options)
             completion = completion
               .. string.format('%d.', index)
               .. string.format(' [%s](%s)', result.title, result.url)
-              .. result.snippet
+              .. string.format(' %s', result.snippet)
               .. string.format(
                 ' (Published: %s, Updated: %s)\n',
                 result.date or '',

--- a/lua/model/providers/perplexity.lua
+++ b/lua/model/providers/perplexity.lua
@@ -63,7 +63,7 @@ function M.request_completion(handlers, params, options)
       local data = extract_chat_data(message.data)
 
       if data == nil then
-        if not message.data == '[DONE]' then
+        if message.data ~= '[DONE]' then
           handlers.on_error(
             vim.inspect({
               data = message.data,


### PR DESCRIPTION
Doing some other work, I noticed that the search results also have a decorated version (with titles, snippets, etc) instead of just the raw links. So this cuts over to use those improved versions.