### PR TITLE
update anthropic models

### DIFF
--- a/lua/model/prompts/chats.lua
+++ b/lua/model/prompts/chats.lua
@@ -261,11 +261,6 @@ local closed = {
       model = 'claude-3-7-sonnet-latest',
       max_tokens = 8192,
     },
-    options = {
-      headers = {
-        ['anthropic-beta'] = 'prompt-caching-2024-07-31,max-tokens-3-5-sonnet-2024-07-15',
-      },
-    },
     run = function(messages, config)
       local msgs = vim.tbl_map(function(msg)
         return {

--- a/lua/model/prompts/chats.lua
+++ b/lua/model/prompts/chats.lua
@@ -245,7 +245,7 @@ local closed = {
     provider = anthropic,
     create = input_if_selection,
     params = {
-      model = 'claude-3-5-sonnet-latest',
+      model = 'claude-3-7-sonnet-latest',
     },
     run = function(messages, config)
       return vim.tbl_deep_extend('force', config.params, {
@@ -258,7 +258,7 @@ local closed = {
     provider = anthropic,
     create = input_if_selection,
     params = {
-      model = 'claude-3-5-sonnet-20240620',
+      model = 'claude-3-7-sonnet-latest',
       max_tokens = 8192,
     },
     options = {

--- a/lua/model/prompts/starters.lua
+++ b/lua/model/prompts/starters.lua
@@ -157,9 +157,6 @@ local closed = {
     provider = anthropic,
     mode = mode.INSERT_OR_REPLACE,
     options = {
-      headers = {
-        ['anthropic-beta'] = 'max-tokens-3-5-sonnet-2024-07-15',
-      },
       trim_code = true,
     },
     params = {

--- a/lua/model/prompts/starters.lua
+++ b/lua/model/prompts/starters.lua
@@ -164,7 +164,7 @@ local closed = {
     },
     params = {
       max_tokens = 8192,
-      model = 'claude-3-5-sonnet-latest',
+      model = 'claude-3-7-sonnet-latest',
       system = 'You are an expert programmer. Provide code which should go between the before and after blocks of code. Respond only with a markdown code block. Use comments within the code if explanations are necessary.',
     },
     builder = function(input, context)

--- a/lua/model/providers/anthropic.lua
+++ b/lua/model/providers/anthropic.lua
@@ -42,7 +42,6 @@ local M = {
       headers = vim.tbl_extend('force', {
         ['Content-Type'] = 'application/json',
         ['x-api-key'] = util.env('ANTHROPIC_API_KEY'),
-        ['anthropic-beta'] = 'messages-2023-12-15',
         ['anthropic-version'] = '2023-06-01',
       }, options.headers or {}),
       body = vim.tbl_deep_extend('force', {


### PR DESCRIPTION
- **feat(llm): upgrade claude model to latest version - Update claude model from 3-5-sonnet to 3-7-sonnet-latest - Consistent model version change across chat and starter prompts - Maintains existing configuration structure**
- **remove no longer needed anthropic beta headers**

Doing this based on an email I just got from Anthropic warning me of impending deprecation (Oct 22 I think).