### PR TITLE
feat(anthropic): support claude-sonnet-5

### DIFF
--- a/lua/model/prompts/chats.lua
+++ b/lua/model/prompts/chats.lua
@@ -254,6 +254,23 @@ local closed = {
       })
     end,
   },
+  ['claude-sonnet-5'] = {
+    provider = anthropic,
+    create = input_if_selection,
+    params = {
+      model = 'claude-sonnet-5',
+      -- Sonnet 5 runs adaptive thinking by default (no `thinking` field sent).
+      -- Give max_tokens plenty of room so thinking doesn't crowd out the answer;
+      -- streaming means large values don't risk HTTP timeouts.
+      max_tokens = 16000,
+    },
+    run = function(messages, config)
+      return vim.tbl_deep_extend('force', config.params, {
+        messages = messages,
+        system = config.system,
+      })
+    end,
+  },
   ['claude:cache'] = {
     provider = anthropic,
     create = input_if_selection,

--- a/lua/model/providers/anthropic.lua
+++ b/lua/model/providers/anthropic.lua
@@ -53,7 +53,12 @@ local M = {
         local data = util.json.decode(msg.data)
 
         if msg.event == 'content_block_delta' then
-          consume(data.delta.text)
+          -- Newer models (e.g. claude-sonnet-5) default to adaptive thinking,
+          -- which streams thinking_delta/signature_delta blocks that have no
+          -- .text field. Only forward actual text deltas.
+          if data.delta.type == 'text_delta' then
+            consume(data.delta.text)
+          end
         elseif msg.event == 'message_delta' then
           util.show(data.usage.output_tokens, 'output tokens')
         elseif msg.event == 'message_stop' then


### PR DESCRIPTION
Sonnet 5 runs adaptive thinking by default (no `thinking` field sent), which streams thinking_delta/signature_delta content_block_delta events that have no `.text`. The provider assumed every delta carried text, so `consume(nil)` crashed with "attempt to concatenate local 'partial' (a nil value)".

Guard the streaming handler to only forward text_delta blocks, and add a `claude-sonnet-5` chat prompt with a larger max_tokens so adaptive thinking doesn't crowd out the answer.